### PR TITLE
Fix Money navigation and mobile UI polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Garden" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="description" content="Grow your wealth — budgets, goals, debt and a living 3D garden that flourishes as your finances do." />
+    <meta name="description" content="Grow your wealth — money, goals, debt and a living 3D garden that flourishes as your finances do." />
     <title>Garden Financial — Grow your wealth</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,8 +45,7 @@ function PublicRoute({ children }) {
 function NotFound() {
   return (
     <div
-      className="min-h-dvh flex flex-col items-center justify-center gap-5 p-6 text-center"
-      style={{ background: 'linear-gradient(155deg, #020c05 0%, #031508 30%, #04101a 60%, #030b14 100%)' }}
+      className="min-h-full flex flex-col items-center justify-center gap-5 p-6 text-center"
     >
       <div
         className="w-14 h-14 rounded-2xl flex items-center justify-center shadow-2xl"
@@ -89,7 +88,7 @@ export default function App() {
               <Route path="/debt"     element={<Navigate to="/money" replace />} />
               <Route path="/accounts" element={<Navigate to="/money" replace />} />
               <Route path="/goals"    element={<Navigate to="/plan#goals" replace />} />
-              <Route path="*" element={<NotFound />} />
+              <Route path="*" element={<ProtectedRoute><NotFound /></ProtectedRoute>} />
             </Routes>
           </BrowserRouter>
         </GardenProvider>

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -38,19 +38,20 @@ export default class ErrorBoundary extends Component {
     }
     if (this.state.error) {
       return (
-        <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 flex flex-col items-center justify-center gap-5 p-6 text-center">
-          <div className="w-14 h-14 bg-green-500 rounded-2xl flex items-center justify-center shadow-lg">
+        <div className="min-h-screen flex flex-col items-center justify-center gap-5 p-6 text-center"
+          style={{ background: 'linear-gradient(155deg, #020c05 0%, #031508 30%, #04101a 60%, #030b14 100%)' }}>
+          <div className="w-14 h-14 bg-green-500 rounded-2xl flex items-center justify-center shadow-2xl">
             <Sprout className="w-8 h-8 text-white" />
           </div>
           <div>
-            <h1 className="text-lg font-bold text-gray-900">Something went wrong</h1>
-            <p className="text-sm text-gray-500 mt-1 max-w-sm">
+            <h1 className="font-display text-2xl font-medium text-white tracking-tight">Something went wrong</h1>
+            <p className="text-sm text-white/45 mt-1 max-w-sm">
               The app hit an unexpected error. Reloading usually clears it — your data is safe.
             </p>
           </div>
           <button
             onClick={() => window.location.reload()}
-            className="inline-flex items-center gap-2 px-5 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-xl text-sm font-semibold shadow-sm transition-colors"
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl text-sm font-semibold shadow-lg shadow-emerald-900/30 transition-colors"
           >
             <RefreshCw className="w-4 h-4" /> Reload
           </button>

--- a/src/components/GoalItem.jsx
+++ b/src/components/GoalItem.jsx
@@ -54,10 +54,12 @@ export function GoalModal({ goal, onSave, onClose }) {
   const inputCls = 'w-full px-3.5 py-2.5 rounded-lg border border-white/[0.11] text-base focus:outline-none focus:ring-1 focus:ring-emerald-400/30'
   return (
     <div className="fixed inset-0 bg-black/60 flex items-end sm:items-center justify-center z-[60]">
-      <div className="bg-[#0e1812] w-full sm:rounded-2xl sm:shadow-xl sm:w-full sm:max-w-md sm:mx-4 rounded-t-2xl shadow-2xl">
+      <div role="dialog" aria-modal="true" aria-labelledby="goal-modal-title"
+        className="bg-[#0e1812] w-full sm:rounded-2xl sm:shadow-xl sm:w-full sm:max-w-md sm:mx-4 rounded-t-2xl shadow-2xl">
         <div className="flex items-center justify-between p-5 border-b border-white/10">
-          <h3 className="font-semibold text-white">{goal ? 'Edit Goal' : 'New Goal'}</h3>
-          <button onClick={onClose} className="p-1.5 text-white/40 hover:text-white/60 rounded-lg hover:bg-white/5">
+          <h3 id="goal-modal-title" className="font-semibold text-white">{goal ? 'Edit Goal' : 'New Goal'}</h3>
+          <button onClick={onClose} aria-label="Close goal editor"
+            className="p-1.5 text-white/40 hover:text-white/60 rounded-lg hover:bg-white/5">
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -187,8 +189,10 @@ function ProgressInput({ goal, accounts = [], onContribute, onUpdate }) {
                 onKeyDown={e => e.key === 'Enter' && addMoney()}
                 className="w-full pl-6 pr-2.5 py-2 rounded-lg border border-white/[0.11] bg-white/[0.085] text-white text-base focus:outline-none focus:ring-1 focus:ring-emerald-400/30" />
             </div>
-            <button onClick={addMoney} className="p-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-500"><Check className="w-3.5 h-3.5" /></button>
-            <button onClick={() => setMode(null)} className="p-2 text-white/40 hover:text-white/60"><X className="w-3.5 h-3.5" /></button>
+            <button onClick={addMoney} aria-label="Add money to goal"
+              className="p-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-500"><Check className="w-3.5 h-3.5" /></button>
+            <button onClick={() => setMode(null)} aria-label="Cancel adding money"
+              className="p-2 text-white/40 hover:text-white/60"><X className="w-3.5 h-3.5" /></button>
           </div>
           {accounts.length > 0 && (
             <div className="flex items-center gap-2">
@@ -210,8 +214,10 @@ function ProgressInput({ goal, accounts = [], onContribute, onUpdate }) {
           <input autoFocus type="number" inputMode="decimal" value={absVal} onChange={e => setAbsVal(e.target.value)}
             min="0" step="0.01"
             className="flex-1 px-2.5 py-2 rounded-lg border border-white/[0.11] bg-white/[0.085] text-white text-base focus:outline-none focus:ring-1 focus:ring-emerald-400/30" />
-          <button onClick={saveAbs} className="p-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-500"><Check className="w-3.5 h-3.5" /></button>
-          <button onClick={() => setMode(null)} className="p-2 text-white/40 hover:text-white/60"><X className="w-3.5 h-3.5" /></button>
+          <button onClick={saveAbs} aria-label="Save goal progress"
+            className="p-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-500"><Check className="w-3.5 h-3.5" /></button>
+          <button onClick={() => setMode(null)} aria-label="Cancel editing progress"
+            className="p-2 text-white/40 hover:text-white/60"><X className="w-3.5 h-3.5" /></button>
         </div>
       ) : (
         <div className="flex items-center gap-3">

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import { useAuth } from '@/context/AuthContext'
-import { Sprout, LayoutDashboard, Target, Bot, Settings } from 'lucide-react'
+import { Sprout, LayoutDashboard, Target, Bot, Settings, Wallet } from 'lucide-react'
 import Onboarding from '@/components/Onboarding'
 
-// Three focused tabs. The Plan holds steps + the ingrained money card + goals;
-// budget lives there, not as its own tab. Advisor builds the plan; the garden
-// grows as you check steps off.
+// Core tabs. Advisor builds the plan; Money holds the user's real financial
+// picture; the garden grows as steps and goals are completed.
 const NAV_ITEMS = [
   { to: '/',        label: 'Garden',  icon: LayoutDashboard },
   { to: '/advisor', label: 'Advisor', icon: Bot },
   { to: '/plan',    label: 'Plan',    icon: Target },
+  { to: '/money',   label: 'Money',   icon: Wallet },
 ]
 const HUD_ITEMS = NAV_ITEMS
 
@@ -166,7 +166,7 @@ export default function Layout({ children }) {
                 <>
                   <Icon className={`w-5 h-5 transition-all duration-200 ${
                     isActive ? 'text-green-300 scale-110 drop-shadow-[0_0_6px_rgba(134,239,172,0.6)]' : ''}`} />
-                  <span className={`text-[8.5px] font-bold tracking-wide transition-all duration-200 ${
+                  <span className={`text-[10px] font-bold tracking-wide transition-all duration-200 ${
                     isActive ? 'text-green-100' : 'text-white/45'}`}>
                     {label.toUpperCase()}
                   </span>

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -233,7 +233,7 @@ function DebtsStep({ debts, setDebts }) {
 export default function Onboarding({ onClose, profileOnly = false }) {
   const { user, profile, setProfile } = useAuth()
   // profileOnly (editing from Settings) shows just the profile questions — no
-  // money/debts re-entry (those live on the Plan and stay untouched).
+  // money/debts re-entry (those live on Your Money and stay untouched).
   const STEPS = profileOnly ? BASE_STEPS.filter(s => !['money', 'debts'].includes(s.id)) : BASE_STEPS
   // When opened manually (editing profile), skip preview + intro → go straight to age
   const startStep = onClose ? 2 : 0
@@ -291,7 +291,7 @@ export default function Onboarding({ onClose, profileOnly = false }) {
     setSaving(true)
 
     // Profile-only edit (from Settings): just save the quiz answers — money,
-    // accounts, debts, and net worth are managed on the Plan and left untouched.
+    // accounts, debts, and net worth are managed on Your Money and left untouched.
     const profileFields = {
       id: user.id,
       first_name: user.user_metadata?.full_name?.split(' ')[0] ?? null,
@@ -384,6 +384,9 @@ export default function Onboarding({ onClose, profileOnly = false }) {
   return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm sm:p-4">
       <motion.div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Garden Financial setup"
         initial={{ opacity: 0, y: 40 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.28, ease: 'easeOut' }}
@@ -505,7 +508,7 @@ export default function Onboarding({ onClose, profileOnly = false }) {
                     </label>
                   ))}
                   <div className="text-[10px] font-semibold text-white/45 uppercase tracking-wide pt-1">What's in your accounts</div>
-                  <div className="grid grid-cols-3 gap-2">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                     {[
                       { field: 'checking',  label: 'Checking',    color: 'focus-within:border-sky-400' },
                       { field: 'savings',   label: 'Savings',     color: 'focus-within:border-emerald-400' },
@@ -524,7 +527,7 @@ export default function Onboarding({ onClose, profileOnly = false }) {
                       </label>
                     ))}
                   </div>
-                  <p className="text-[11px] text-white/35">Estimates are fine — you can fine-tune these in your Plan later.</p>
+                  <p className="text-[11px] text-white/35">Estimates are fine — you can fine-tune these in Your Money later.</p>
                 </div>
               )}
 

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -507,7 +507,7 @@ export default function Onboarding({ onClose, profileOnly = false }) {
                       </div>
                     </label>
                   ))}
-                  <div className="text-[10px] font-semibold text-white/45 uppercase tracking-wide pt-1">What's in your accounts</div>
+                  <div className="text-[10px] font-semibold text-white/45 uppercase tracking-wide pt-1">What&apos;s in your accounts</div>
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                     {[
                       { field: 'checking',  label: 'Checking',    color: 'focus-within:border-sky-400' },

--- a/src/context/GardenContext.jsx
+++ b/src/context/GardenContext.jsx
@@ -41,7 +41,7 @@ export function GardenProvider({ children }) {
   })
 
   // Growth is driven by milestones; a light weather layer still reflects the
-  // money card (negative surplus → clouds/rain) so budget shows up visually.
+  // user's money picture (negative surplus → clouds/rain).
   const updateGarden = useCallback(({
     completedSteps = 0, totalSteps = 0, goalsReached = 0,
     surplusRatio = 0, netWorth = 0, goals: gGoals = [], debts: gDebts = [],

--- a/src/pages/AIAdvisor.jsx
+++ b/src/pages/AIAdvisor.jsx
@@ -180,12 +180,12 @@ function buildContext(money, goals, debts, profile, extras = {}) {
   const netWorth = acctTotal - totalDebt
 
   if (income === 0 && expenses === 0 && goals.length === 0 && debts.length === 0 && !netWorth && acctTotal === 0) {
-    return 'The user has not added any financial data yet. Encourage them to fill in their monthly income, expenses, and net worth in the "Your money" card on the Plan tab, set a savings goal, and — most valuably — ask you to build them an action plan. Their garden grows as they complete plan steps.'
+    return 'The user has not added any financial data yet. Encourage them to fill in their monthly income, expenses, accounts, assets, and debts on the Your Money page, set a savings goal, and — most valuably — ask you to build them an action plan. Their garden grows as they complete plan steps.'
   }
 
   let ctx = ''
 
-  // ── Money snapshot (from the "Your money" card on the Plan tab) ─────────────
+  // ── Money snapshot (from the Your Money page) ───────────────────────────────
   const surplus = net >= 0 ? `+$${net.toLocaleString()} surplus` : `-$${Math.abs(net).toLocaleString()} DEFICIT`
   ctx += `MONTHLY MONEY:\n`
   ctx += `  Income:   $${income.toLocaleString()}/mo\n`
@@ -406,7 +406,7 @@ function WelcomeScreen({ hasData, onSuggest, analyzing, onBuildPlan, building })
       <p className="text-white/50 text-sm max-w-sm mx-auto leading-relaxed mb-6">
         {hasData
           ? "I've looked at your numbers. Want me to tell you exactly where you stand and build you a plan?"
-          : "Ask me anything — and I'll build you a plan you can check off to grow your garden. Add your money & goals on the Plan tab for advice that's about you."}
+          : "Ask me anything — and I'll build you a plan you can check off to grow your garden. Add your money on the Money tab and goals on the Plan tab for advice that's about you."}
       </p>
 
       {hasData && (
@@ -536,7 +536,7 @@ export default function AIAdvisor() {
     setAtBottom(distFromBottom < 80)
   }, [])
 
-  // The "Your money" snapshot lives on the profile (edited in the Plan's money card).
+  // The Your Money snapshot lives on the profile and account/debt rows.
   const money = useMemo(() => ({
     income:   Number(profile?.monthly_income)   || 0,
     expenses: Number(profile?.monthly_expenses) || 0,
@@ -649,6 +649,7 @@ export default function AIAdvisor() {
               <button
                 onClick={handleBuildPlan}
                 disabled={buildingPlan || loading || analyzing}
+                aria-label="Generate a saveable action plan"
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/15 border border-emerald-400/30 text-emerald-200 text-xs font-semibold hover:bg-emerald-500/25 transition-colors disabled:opacity-50"
                 title="Generate a saveable action plan"
               >
@@ -667,6 +668,7 @@ export default function AIAdvisor() {
                   localStorage.removeItem(STORAGE_KEY)
                   supabase.from('conversations').delete().eq('user_id', user.id).then(() => {})
                 }}
+                aria-label="Start over"
                 className="p-1.5 rounded-lg text-white/40 hover:text-white hover:bg-white/10 transition-colors"
                 title="Start over"
               >
@@ -700,6 +702,7 @@ export default function AIAdvisor() {
               initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }}
               onClick={() => { setAtBottom(true); bottomRef.current?.scrollIntoView({ behavior: 'smooth' }) }}
+              aria-label="Scroll to latest message"
               className="fixed bottom-36 md:bottom-24 right-4 z-10 w-9 h-9 bg-white/15 backdrop-blur-md border border-white/10 shadow-lg rounded-full flex items-center justify-center text-white/70 hover:text-emerald-300 hover:border-emerald-400/50 transition-colors"
             >
               <ArrowDown className="w-4 h-4" />
@@ -791,7 +794,7 @@ export default function AIAdvisor() {
                 onFocus={() => setInputFocused(true)}
                 onBlur={() => setInputFocused(false)}
                 onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(input) } }}
-                placeholder={noKey ? 'Add your API key to start…' : 'Ask anything about your finances…'}
+                placeholder={noKey ? 'Advisor not configured yet…' : 'Ask anything about your finances…'}
                 disabled={noKey || loading || analyzing}
                 rows={1}
                 className="w-full bg-transparent text-base md:text-sm text-white placeholder-white/35 focus:outline-none resize-none leading-relaxed disabled:opacity-50"
@@ -799,6 +802,7 @@ export default function AIAdvisor() {
               />
             </div>
             <button type="submit" disabled={!input.trim() || loading || analyzing || noKey}
+              aria-label="Send message"
               className="w-11 h-11 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:bg-white/10 disabled:cursor-not-allowed text-white flex items-center justify-center transition-colors flex-shrink-0 shadow-lg shadow-emerald-900/30">
               <Send className="w-4 h-4" />
             </button>

--- a/src/pages/AIAdvisor.jsx
+++ b/src/pages/AIAdvisor.jsx
@@ -16,7 +16,7 @@ const GOAL_INTENT = /\b(sav(e|ing|ings)|buy|buying|afford|down\s?-?payment|house
 const GUIDE_INTENT = /\b(open|start|set\s?up|sign\s?up|create|switch|roll\s?over|move|transfer|enroll)\b[^.?!]*\b(roth|ira|401k|403b|hsa|brokerage|savings? account|hysa|high.?yield|index fund|etf|mutual fund|emergency fund|life insurance|will|credit|account|invest)\b|\bwalk me through\b|\bstep[-\s]?by[-\s]?step\b|\bhow (do|can) i (open|start|set\s?up|sign\s?up|get|invest)\b/i
 import {
   Send, Bot, Sparkles, RefreshCw, ArrowDown,
-  Target, BarChart3, PiggyBank, CreditCard, TrendingUp, Lightbulb, Shield, Sprout,
+  Target, BarChart3, PiggyBank, CreditCard, TrendingUp, Shield, Sprout,
   ClipboardList, Loader2,
 } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -493,13 +493,13 @@ export default function AIAdvisor() {
         const remoteMessages = conv.data.messages
         setMessages(prev => remoteMessages.length >= prev.length ? remoteMessages : prev)
         // Update localStorage cache
-        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(remoteMessages)) } catch {}
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(remoteMessages)) } catch { /* ignore cache write failures */ }
       }
       isLoadingHistory.current = false
       setHistoryLoading(false)
     }
     load()
-  }, [user.id])
+  }, [STORAGE_KEY, user.id])
 
   // A Plan "Smart next step" can route here with a pre-filled question — auto-ask it.
   useEffect(() => {
@@ -514,7 +514,7 @@ export default function AIAdvisor() {
   useEffect(() => {
     if (isLoadingHistory.current) return
     if (loading || analyzing) return
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(messages)) } catch {}
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(messages)) } catch { /* ignore cache write failures */ }
     // Supabase upsert — fire and forget
     supabase.from('conversations').upsert(
       { user_id: user.id, messages, updated_at: new Date().toISOString() },

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -219,7 +219,7 @@ export default function Dashboard() {
               <Link to="/advisor"
                 className="flex items-center gap-2.5 px-3 py-2 bg-emerald-500/15 rounded-xl border border-emerald-400/25 hover:bg-emerald-500/25 transition-all group">
                 <Bot className="w-4 h-4 text-emerald-300 flex-shrink-0" />
-                <span className="flex-1 min-w-0 text-xs font-semibold text-white truncate">All steps done — ask your advisor what's next</span>
+                <span className="flex-1 min-w-0 text-xs font-semibold text-white truncate">All steps done — ask your advisor what&apos;s next</span>
                 <ArrowRight className="w-3.5 h-3.5 text-emerald-300 flex-shrink-0 group-hover:translate-x-0.5 transition-transform" />
               </Link>
             )

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { Sprout, Bot, ArrowRight, UserCircle, Check, ClipboardList, TrendingUp, TrendingDown } from 'lucide-react'
+import { Sprout, Bot, ArrowRight, UserCircle, Check, ClipboardList, TrendingUp, TrendingDown, ChevronRight } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/context/AuthContext'
 import { useGarden, milestonesToStage, STAGE_NAMES, STAGE_THRESHOLDS } from '@/context/GardenContext'
@@ -46,12 +46,12 @@ function GardenHud({ stage, done }) {
   const remaining = next ? next - done : 0
   return (
     <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
-      <div className="flex items-center gap-2.5 bg-black/45 backdrop-blur-md border border-white/10 rounded-full pl-3.5 pr-4 py-1.5 shadow-lg">
+      <div className="flex items-center gap-2 bg-black/45 backdrop-blur-md border border-white/10 rounded-full pl-3.5 pr-3 py-1.5 shadow-lg max-w-[calc(100vw-2rem)]">
         <span className="w-2.5 h-2.5 rounded-full ring-2 ring-white/20"
           style={{ background: ['#8a6a44','#a3b35a','#6cc24a','#3fa53b','#2f9e44','#34d399'][stage] }} />
-        <span className="text-xs font-bold text-white whitespace-nowrap">{STAGE_NAMES[stage]}</span>
+        <span className="text-xs font-bold text-white truncate max-w-[7.5rem]">{STAGE_NAMES[stage]}</span>
         <span className="text-white/25 text-[10px]">·</span>
-        <span className="text-[10px] font-semibold text-green-200/90 whitespace-nowrap tabular-nums">
+        <span className="text-[10px] font-semibold text-green-200/90 truncate tabular-nums">
           {stage >= 5
             ? 'fully grown 🌸'
             : `${remaining} more step${remaining === 1 ? '' : 's'} → ${STAGE_NAMES[stage + 1]}`}
@@ -159,7 +159,7 @@ export default function Dashboard() {
 
         {/* Assets + net worth — tap to open Your Money */}
         {!loading && (
-          <Link to="/money" className="grid grid-cols-2 gap-2.5 group">
+          <Link to="/money" className="grid grid-cols-2 gap-2.5 group" aria-label="Open Your Money details">
             <div className="bg-white/[0.075] rounded-xl border border-white/[0.11] px-3 py-2 group-hover:bg-white/[0.11] transition-colors">
               <div className="text-[10px] font-semibold text-white/45 uppercase tracking-wide">Assets</div>
               <div className="text-base font-bold tabular-nums text-emerald-200 leading-tight">{fmt$(accountValue)}</div>
@@ -174,7 +174,12 @@ export default function Dashboard() {
                   </span>
                 )}
               </div>
-              <div className={`text-base font-bold tabular-nums leading-tight ${netWorth >= 0 ? 'text-white' : 'text-rose-300'}`}>{fmt$(netWorth)}</div>
+              <div className="flex items-center justify-between gap-2">
+                <div className={`text-base font-bold tabular-nums leading-tight ${netWorth >= 0 ? 'text-white' : 'text-rose-300'}`}>{fmt$(netWorth)}</div>
+                <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold text-emerald-200/80">
+                  View <ChevronRight className="w-3 h-3" />
+                </span>
+              </div>
             </div>
           </Link>
         )}
@@ -201,6 +206,7 @@ export default function Dashboard() {
                 </div>
                 {nextSteps.map(({ planId, step }) => (
                   <button key={step.id} onClick={() => toggleStep(planId, step.id, step.text)}
+                    aria-label={`Mark "${step.text}" complete`}
                     className="w-full flex items-center gap-2.5 px-1 py-1 text-left group">
                     <span className="w-[18px] h-[18px] rounded-md border border-white/30 group-hover:border-emerald-400 flex items-center justify-center flex-shrink-0 transition-colors">
                       <Check className="w-3 h-3 text-emerald-300 opacity-0 group-hover:opacity-100 transition-opacity" strokeWidth={3} />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -101,11 +101,13 @@ export default function Login() {
           }}
         >
           {/* Tab switcher */}
-          <div className="flex rounded-xl p-0.5 mb-6" style={{ background: 'rgba(255,255,255,0.06)' }}>
+          <div role="tablist" aria-label="Authentication mode" className="flex rounded-xl p-0.5 mb-6" style={{ background: 'rgba(255,255,255,0.06)' }}>
             {['login', 'signup'].map(m => (
               <button
                 key={m}
                 type="button"
+                role="tab"
+                aria-selected={mode === m}
                 onClick={() => { setMode(m); setError(''); setMessage('') }}
                 className={`flex-1 py-2 text-sm font-semibold rounded-[10px] transition-all duration-200 ${
                   mode === m

--- a/src/pages/Money.jsx
+++ b/src/pages/Money.jsx
@@ -34,7 +34,8 @@ function EditableAmount({ label, value, onSave, color = 'text-white', hint }) {
           onBlur={() => { if (cancelled.current) { cancelled.current = false; return } commit() }}
           onKeyDown={e => { if (e.key === 'Enter') commit(); if (e.key === 'Escape') { cancelled.current = true; setEditing(false) } }}
           className="w-full bg-transparent text-sm font-bold text-white tabular-nums focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
-        <button onMouseDown={e => e.preventDefault()} onClick={commit} className="p-0.5 text-emerald-400"><Check className="w-3.5 h-3.5" /></button>
+        <button onMouseDown={e => e.preventDefault()} onClick={commit} aria-label={`Save ${label}`}
+          className="p-0.5 text-emerald-400"><Check className="w-3.5 h-3.5" /></button>
       </div>
     )
   }
@@ -52,19 +53,22 @@ function LineRow({ item, showRate, onUpdate, onDelete }) {
   const [bal, setBal]   = useState(String(item.balance ?? 0))
   const [rate, setRate] = useState(item.interest_rate != null ? String(item.interest_rate) : '')
   return (
-    <div className="flex items-center gap-1.5 py-1.5">
+    <div className="flex flex-wrap sm:flex-nowrap items-center gap-1.5 py-1.5">
       <input value={name} onChange={e => setName(e.target.value)}
+        aria-label={`${item.name || 'Item'} name`}
         onBlur={() => { if (name.trim() && name !== item.name) onUpdate(item.id, { name }) }}
-        className="flex-1 min-w-0 px-2 py-1.5 rounded-lg border border-white/[0.08] bg-white/[0.04] text-white/90 text-sm focus:outline-none focus:border-emerald-400/40" />
+        className="w-full sm:flex-1 sm:min-w-0 px-2 py-1.5 rounded-lg border border-white/[0.08] bg-white/[0.04] text-white/90 text-sm focus:outline-none focus:border-emerald-400/40" />
       <div className="flex items-center bg-white/[0.04] border border-white/[0.08] rounded-lg px-2 py-1.5 w-[88px]">
         <span className="text-white/40 text-xs">$</span>
         <input type="number" inputMode="decimal" value={bal} onChange={e => setBal(e.target.value)}
+          aria-label={`${item.name || 'Item'} balance`}
           onBlur={() => { const n = parseFloat(bal); if (!isNaN(n) && n !== Number(item.balance)) onUpdate(item.id, { balance: n }) }}
           className="w-full min-w-0 bg-transparent text-sm font-semibold text-white tabular-nums focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
       </div>
       {showRate && (
         <div className="flex items-center bg-white/[0.04] border border-white/[0.08] rounded-lg px-1.5 py-1.5 w-[58px]">
           <input type="number" inputMode="decimal" value={rate} onChange={e => setRate(e.target.value)} placeholder="—"
+            aria-label={`${item.name || 'Debt'} interest rate`}
             onBlur={() => { const n = parseFloat(rate); const cur = item.interest_rate ?? null; if ((isNaN(n) ? null : n) !== cur) onUpdate(item.id, { interest_rate: isNaN(n) ? null : n }) }}
             className="w-full min-w-0 bg-transparent text-sm font-semibold text-amber-200 tabular-nums focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
           <span className="text-white/35 text-xs">%</span>
@@ -119,25 +123,29 @@ function LineItemList({ icon: Icon, title, accent = 'emerald', items, presets = 
             ))}
           </div>
         )}
-        <div className="flex gap-1.5 items-center pt-1.5 pb-1">
+        <div className="flex flex-wrap sm:flex-nowrap gap-1.5 items-center pt-1.5 pb-1">
           <input value={name} onChange={e => setName(e.target.value)} placeholder="Name"
+            aria-label={`New ${title.toLowerCase()} name`}
             onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }}
-            className="flex-1 min-w-0 px-2.5 py-1.5 rounded-lg border border-white/[0.08] bg-white/[0.06] text-white text-sm focus:outline-none focus:ring-1 focus:ring-emerald-400/30" />
+            className="w-full sm:flex-1 sm:min-w-0 px-2.5 py-1.5 rounded-lg border border-white/[0.08] bg-white/[0.06] text-white text-sm focus:outline-none focus:ring-1 focus:ring-emerald-400/30" />
           <div className="flex items-center bg-white/[0.06] border border-white/[0.08] rounded-lg px-2 py-1.5 w-[88px]">
             <span className="text-white/40 text-xs">$</span>
             <input type="number" inputMode="decimal" value={bal} onChange={e => setBal(e.target.value)} placeholder="0"
+              aria-label={`New ${title.toLowerCase()} balance`}
               onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }}
               className="w-full min-w-0 bg-transparent text-sm text-white tabular-nums focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
           </div>
           {showRate && (
             <div className="flex items-center bg-white/[0.06] border border-white/[0.08] rounded-lg px-1.5 py-1.5 w-[58px]">
               <input type="number" inputMode="decimal" value={rate} onChange={e => setRate(e.target.value)} placeholder="APR"
+                aria-label={`New ${title.toLowerCase()} interest rate`}
                 onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }}
                 className="w-full min-w-0 bg-transparent text-sm text-amber-200 tabular-nums focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
               <span className="text-white/35 text-xs">%</span>
             </div>
           )}
           <button onClick={add} disabled={!name.trim() || bal === '' || !(parseFloat(bal) >= 0)}
+            aria-label={`Add ${title.toLowerCase()} item`}
             className={`p-1.5 rounded-lg text-white transition-colors flex-shrink-0 disabled:bg-white/10 disabled:text-white/30 ${c.btn}`}>
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -249,13 +257,18 @@ export default function Money() {
     supabase.from('debts').delete().eq('id', id).then(() => {})
   }
 
+  function goBack() {
+    if (document.referrer.startsWith(window.location.origin) && window.history.length > 1) navigate(-1)
+    else navigate('/')
+  }
+
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.25 }}
       className="max-w-xl mx-auto w-full px-4 pt-2 pb-10">
 
       {/* Header */}
       <div className="flex items-center gap-2 mb-4">
-        <button onClick={() => navigate(-1)} aria-label="Back"
+        <button onClick={goBack} aria-label="Back"
           className="p-1.5 -ml-1.5 rounded-lg text-white/55 hover:text-white hover:bg-white/10 transition-colors">
           <ChevronLeft className="w-5 h-5" />
         </button>
@@ -277,7 +290,7 @@ export default function Money() {
         {/* Monthly cash flow */}
         <div className="bg-white/[0.05] rounded-2xl border border-white/[0.10] px-4 py-3.5">
           <div className="text-[10px] font-semibold text-white/45 uppercase tracking-wide mb-2.5">Monthly cash flow</div>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <EditableAmount label="Income"   value={income}   onSave={v => saveMoney({ monthly_income: v })}   color="text-emerald-300" />
             <EditableAmount label="Expenses" value={expenses} onSave={v => saveMoney({ monthly_expenses: v })} color="text-rose-300" />
             <div>
@@ -297,7 +310,7 @@ export default function Money() {
             <span className="text-sm font-semibold text-white">Cash & savings</span>
             <span className="ml-auto text-sm font-bold tabular-nums text-sky-200">{fmt(checking + savings)}</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <EditableAmount label="Checking & cash" value={checking} onSave={v => saveCanonical('checking', 'Checking', v)} color="text-sky-200" />
             <EditableAmount label="Savings (HYSA)"   value={savings}  onSave={v => saveCanonical('savings', 'Savings', v)}   color="text-emerald-200" />
           </div>

--- a/src/pages/Plan.jsx
+++ b/src/pages/Plan.jsx
@@ -180,7 +180,6 @@ export default function Plan() {
   const howTo = (step) => askAdvisor(
     `Walk me through exactly how to do this, step by step: "${step.text}". Give me the specific actions to take, and based on my situation tell me roughly how much I should aim to put in or contribute.`)
 
-  const stepsLeft   = totalSteps - completedSteps
   const isComplete  = p => p.steps.length > 0 && p.steps.every(s => s.done)
   const sortedPlans = [...plans].sort((a, b) => (isComplete(a) === isComplete(b) ? 0 : isComplete(a) ? 1 : -1))
 

--- a/src/pages/Plan.jsx
+++ b/src/pages/Plan.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { ClipboardList, Bot, Target, Plus, Sprout } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
@@ -14,6 +14,7 @@ import GardenGrowthToast from '@/components/GardenGrowthToast'
 export default function Plan() {
   const { user, profile, setProfile } = useAuth()
   const { updateGarden } = useGarden()
+  const location = useLocation()
   const navigate = useNavigate()
   const [plans,   setPlans]   = useState([])
   const [goals,   setGoals]   = useState([])
@@ -54,9 +55,9 @@ export default function Plan() {
   // Deep-link support: /plan#goals etc.
   useEffect(() => {
     if (loading) return
-    const id = window.location.hash.slice(1)
+    const id = location.hash.slice(1)
     if (id) setTimeout(() => document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 150)
-  }, [loading])
+  }, [loading, location.hash])
 
   // ── Derived milestone counts ─────────────────────────────────────────────────
   const completedSteps = plans.reduce((n, p) => n + p.steps.filter(s => s.done).length, 0)
@@ -219,7 +220,7 @@ export default function Plan() {
             onAddTask={addSuggestedTask} onAddGoal={addSuggestedGoal} onAsk={askAdvisor} />
 
           {/* ── Action steps (the hero — checking grows the garden) ── */}
-          <section id="steps" className="scroll-mt-16">
+          <section id="steps" className="scroll-mt-20">
             <div className="flex items-center justify-between mb-2.5">
               <h2 className="text-sm font-semibold text-white flex items-center gap-1.5">
                 <ClipboardList className="w-4 h-4 text-emerald-300" /> Action steps
@@ -259,7 +260,7 @@ export default function Plan() {
           </section>
 
           {/* ── Goals ── */}
-          <section id="goals" className="scroll-mt-16 space-y-3">
+          <section id="goals" className="scroll-mt-20 space-y-3">
             <div className="flex items-center justify-between">
               <h2 className="text-sm font-semibold text-white flex items-center gap-1.5">
                 <Target className="w-4 h-4 text-emerald-300" /> Goals

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -115,13 +115,18 @@ export default function Settings() {
     navigate('/login')
   }
 
+  function goBack() {
+    if (document.referrer.startsWith(window.location.origin) && window.history.length > 1) navigate(-1)
+    else navigate('/')
+  }
+
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.25 }}
       className="max-w-xl mx-auto w-full px-4 pt-2 pb-10">
 
       {/* Header */}
       <div className="flex items-center gap-2 mb-5">
-        <button onClick={() => navigate(-1)} aria-label="Back"
+        <button onClick={goBack} aria-label="Back"
           className="p-1.5 -ml-1.5 rounded-lg text-white/55 hover:text-white hover:bg-white/10 transition-colors">
           <ChevronLeft className="w-5 h-5" />
         </button>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext'
 import Onboarding from '@/components/Onboarding'
 import {
   ChevronLeft, UserCircle, Pencil, Wallet, ArrowRight, Download, ShieldCheck,
-  LogOut, Trash2, Loader2, Check,
+  LogOut, Trash2, Loader2,
 } from 'lucide-react'
 
 const APP_VERSION = '1.0'
@@ -164,7 +164,7 @@ export default function Settings() {
             </span>
             <p className="text-xs text-white/50 leading-relaxed">
               Your data is private to your account. Garden Financial offers educational
-              guidance — it isn't a substitute for a licensed financial planner.
+              guidance — it isn&apos;t a substitute for a licensed financial planner.
             </p>
           </div>
         </Card>
@@ -184,7 +184,7 @@ export default function Settings() {
               <p className="text-sm text-rose-100 font-medium">Delete everything?</p>
               <p className="text-xs text-white/55 leading-relaxed">
                 This permanently deletes your profile, money, goals, debts, plans, and advisor
-                history, then signs you out. This can't be undone.
+                history, then signs you out. This can&apos;t be undone.
               </p>
               <div className="flex gap-2">
                 <button onClick={() => setConfirmDelete(false)} disabled={deleting}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the dedicated Money page to primary desktop/mobile navigation and refresh stale Plan-money copy.
- Improve mobile layouts for Money and onboarding money inputs, plus safer in-app Back behavior.
- Polish dashboard Money affordance, signed-in 404/error states, and accessibility labels for compact icon controls.

## Testing
- `npx eslint src/App.jsx src/components/ErrorBoundary.jsx src/components/GoalItem.jsx src/components/Layout.jsx src/components/Onboarding.jsx src/context/GardenContext.jsx src/pages/AIAdvisor.jsx src/pages/Dashboard.jsx src/pages/Login.jsx src/pages/Money.jsx src/pages/Plan.jsx src/pages/Settings.jsx --rule 'react/prop-types: off'` (passes with 5 existing Fast Refresh warnings)
- `npm run build` (passes; Vite reports existing large chunk warnings)

## Notes
- Full `npm run lint` remains blocked by pre-existing repository-wide ESLint issues, mainly missing React prop validation and React Three Fiber JSX unknown-property rules.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9232f501-59fd-447b-b60b-70bd00ee4c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9232f501-59fd-447b-b60b-70bd00ee4c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

