### PR TITLE
Set up dev environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this app is
+Garden Financial is a **Vite + React 18 single-page app**. **Supabase is the entire backend** (Postgres, Auth, Edge Functions) — there is **no separate backend server**. See `README.md` for the authoritative overview.
+
+> Ignore `start.sh`, `STATUS.md`, and `LAUNCH.md`. They are stale leftovers describing an old Express + SQLite backend (`npm run full-dev`, `backend/`, `demo@example.com`) that no longer exists. The real scripts are only those in `package.json`.
+
+### Commands (all from repo root)
+- `npm run dev` — dev server on http://localhost:5173 (the dev command to use)
+- `npm run build` — production build to `dist/`
+- `npm run preview` — preview the production build
+- `npm run lint` — ESLint. Note: lint currently reports **hundreds of pre-existing errors** (mostly `react/prop-types` and a few `no-undef` in config files). These are not caused by environment setup; do not treat a non-zero `lint` exit as a broken environment.
+
+### Required: `.env` for the app to boot
+`src/lib/supabase.js` calls `createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY)` at import time. With **no** `.env`, `createClient` throws and the SPA renders blank. Create a gitignored `.env` (it is in `.gitignore`):
+
+```
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-public-key
+```
+
+- With **placeholder** values (e.g. `https://placeholder.supabase.co` + any string) the app boots and renders the `/login` page, but any auth/data call fails with "Failed to fetch". This is enough to verify the frontend dev environment renders.
+- For **real** end-to-end auth + data (sign up, onboarding, dashboard, goals, accounts), you need a real Supabase project's URL + anon key in `.env`. These are not committed and must be supplied as secrets.
+
+### Backend schema is NOT in the repo
+The base tables (`profiles`, `accounts`, `budgets`, `goals`, `debts`, `advisor_plans`, `conversations`, `net_worth_snapshots`, `budget_limits`) are **not** defined anywhere in the repo — `supabase/migrations.sql` and `SETUP.md` only contain incremental ALTERs. The canonical schema lives in the hosted Supabase project, so a fully working backend cannot be reconstructed locally from this repo alone.
+
+### AI advisor (optional)
+The advisor uses the Supabase Edge Function in `supabase/functions/chat` (Deno), which holds `ANTHROPIC_API_KEY` as a server-side Supabase secret. It is deployed separately via the Supabase CLI and is **not** needed to run the SPA locally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ VITE_SUPABASE_ANON_KEY=your-anon-public-key
 - With **placeholder** values (e.g. `https://placeholder.supabase.co` + any string) the app boots and renders the `/login` page, but any auth/data call fails with "Failed to fetch". This is enough to verify the frontend dev environment renders.
 - For **real** end-to-end auth + data (sign up, onboarding, dashboard, goals, accounts), you need a real Supabase project's URL + anon key in `.env`. These are not committed and must be supplied as secrets.
 
+> **Gotcha — use the right Supabase key type.** `VITE_SUPABASE_ANON_KEY` must be the **publishable / anon** client key: either the new-format `sb_publishable_...` key or the legacy anon JWT (starts with `eyJ`). It must **not** be a secret key (`sb_secret_...`, the new service-role key). `supabase-js` refuses secret keys in the browser with the error **"Forbidden use of secret API key in browser"**, so auth/data calls fail even though the same secret key works for server-side `curl` against the REST/auth endpoints. (Email confirmation is disabled on the hosted project, so a valid signup logs the user straight in.)
+
 ### Backend schema is NOT in the repo
 The base tables (`profiles`, `accounts`, `budgets`, `goals`, `debts`, `advisor_plans`, `conversations`, `net_worth_snapshots`, `budget_limits`) are **not** defined anywhere in the repo — `supabase/migrations.sql` and `SETUP.md` only contain incremental ALTERs. The canonical schema lives in the hosted Supabase project, so a fully working backend cannot be reconstructed locally from this repo alone.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for Garden Financial (a Vite + React SPA with Supabase as the backend) and documents durable setup notes for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: the real architecture (Supabase is the whole backend; `start.sh`/`STATUS.md`/`LAUNCH.md` are stale), the `npm` commands, the required `.env`, the Supabase key-type gotcha (publishable/anon vs secret), the fact that the base DB schema is not in the repo, and the optional AI advisor edge function.
- Update script set to `npm install` (minimal dependency refresh).

## Verification
- `npm install` — 483 packages installed.
- `npm run lint` — runs (reports hundreds of pre-existing `react/prop-types`/`no-undef` errors, unrelated to setup).
- `npm run build` — succeeds (`dist/` produced).
- `npm run dev` — serves http://localhost:5173 (HTTP 200); app renders the real Login UI.
- Supabase auth reachable: a server-side `curl` signup against `/auth/v1/signup` returned an access token (email confirmation disabled).

## Known blocker
Browser-based auth could not be completed: the supplied `VITE_SUPABASE_ANON_KEY` is a **secret** key (`sb_secret_…`), which `supabase-js` refuses to use in the browser ("Forbidden use of secret API key in browser"). Full end-to-end (signup → onboarding → dashboard) needs the project's **publishable/anon** key instead.

## Walkthrough
[Login page rendered](https://cursor.com/agents/bc-96c96493-cbbf-4be8-a1c2-e56c8915aa07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_page_rendered.webp)
[Sign up form filled](https://cursor.com/agents/bc-96c96493-cbbf-4be8-a1c2-e56c8915aa07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignup_form_filled.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96c96493-cbbf-4be8-a1c2-e56c8915aa07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96c96493-cbbf-4be8-a1c2-e56c8915aa07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

